### PR TITLE
Added option to "redirect to root" in non default language.

### DIFF
--- a/language-redirect.php
+++ b/language-redirect.php
@@ -36,7 +36,9 @@ function language_redirect_plugins_loaded() {
 	if ($redirect_location == null) {
 		return;
 	}
-	if ($redirect_location[0] == '/') {
+    if ( $redirect_location == '/' ) {
+        return;
+    } else if ($redirect_location[0] == '/') {
 		header("Location: ".site_url($redirect_location));
 	} else {
 		header("Location: ".$redirect_location);


### PR DESCRIPTION
In our scenario we have "Polish" variant as root site, and English under "/en/". Nevertheless we want Polish one to be available only when using Polish locale in browser, and English otherwise. So to be able to use following config:

**Default redirect location**: _/en/_
**Language redirect mapping**: _pl=/_

This change is necessary.

Regards,
Adam
